### PR TITLE
Closes #37 refactor: product 테이블에 closeDate 인덱스 추가

### DIFF
--- a/src/main/java/com/kkumta/timedeal/domain/product/Product.java
+++ b/src/main/java/com/kkumta/timedeal/domain/product/Product.java
@@ -11,13 +11,16 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Table(indexes = @Index(name = "index_close", columnList = "closeDate"))
 @Entity
 public class Product extends BaseTimeEntity {
     


### PR DESCRIPTION
상품 구매 마감일을 기준으로 하는 상품 목록 조회 성능을 개선했습니다. 구체적으로, 상품 구매 마감일을 기준으로 하는 상품 목록 조회 API의 응답 속도를 1/2 가량으로 단축했습니다.